### PR TITLE
torrentファイルの情報を表示する機能

### DIFF
--- a/torrent/info.py
+++ b/torrent/info.py
@@ -1,0 +1,30 @@
+import libtorrent as lt
+
+
+def show_info(torrent_name):
+    """
+    トレントファイルの情報を表示する。
+
+    Parameters
+    ----------
+    torrent_name : str
+        トレントファイル名。
+    """
+
+    torrent_info = lt.torrent_info(torrent_name)
+
+    # Torrentの名前を取得する
+    name = torrent_info.name
+    print(f'Torrentの名前: {name}')
+
+    # Torrentのファイル数を取得する
+    num_files = torrent_info.num_files()
+    print(f'Torrentのファイル数: {num_files}')
+
+    # Torrentの作成者を取得する
+    created_by = torrent_info.creator()
+    print(f'Torrentの作成者: {created_by}')
+
+    # Torrentの総サイズを取得する
+    total_size = torrent_info.total_size()
+    print(f'Torrentの総サイズ: {total_size} bytes')

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -1,0 +1,22 @@
+import unittest
+import urllib.request
+import info
+
+
+class TestInfo(unittest.TestCase):
+
+    def test_show_info(self):
+        # テスト用にCreative Commons torrentを用いる
+        # Big Buck Bunny
+        # Blender Foundation | www.blender.org
+        url = 'https://webtorrent.io/torrents/big-buck-bunny.torrent'
+        save_name = 'big-buck-bunny.torrent'
+
+        # 現状、プロジェクト直下に.torrentファイルが落ちてくる
+        urllib.request.urlretrieve(url, save_name)
+
+        info.show_info(save_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
torrentファイルをweb上からダウンロードして、名前、ファイル数、作成者、総サイズを表示する機能を実装しました。
ここでいう「ダウンロード」は単なるファイルのダウンロードで、torrentの機能はまだ使っていません。

テスト用にダウンロードするtorrentファイルには、[webtorrent公式サイトのfree-torrents一覧](https://webtorrent.io/free-torrents)から"Big Buck Bunny"を選びました。
Blender公式からCreative Commonsとして配布されていて、権利的に問題ないものです。

`python test_download_torrent.py` として実行すると、上記サイトからtorrentファイルをダウンロードして情報を表示します。