### PR TITLE
ダウンロードのテストコードの見直し

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#P2Pslayer
+*.torrent
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/torrent/info.py
+++ b/torrent/info.py
@@ -1,7 +1,7 @@
 import libtorrent as lt
 
 
-def show_info(torrent_name):
+def show_info(torrent_info):
     """
     トレントファイルの情報を表示する。
 
@@ -10,8 +10,6 @@ def show_info(torrent_name):
     torrent_name : str
         トレントファイル名。
     """
-
-    torrent_info = lt.torrent_info(torrent_name)
 
     # Torrentの名前を取得する
     name = torrent_info.name

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -1,21 +1,24 @@
 import unittest
+import os
+import libtorrent as lt
 import urllib.request
 import info
 
 
 class TestInfo(unittest.TestCase):
+    TEST_DIR = 'torrent/tests'
 
     def test_show_info(self):
         # テスト用にCreative Commons torrentを用いる
         # Big Buck Bunny
         # Blender Foundation | www.blender.org
         url = 'https://webtorrent.io/torrents/big-buck-bunny.torrent'
-        save_name = 'big-buck-bunny.torrent'
+        save_name = os.path.join(self.TEST_DIR, 'big-buck-bunny.torrent')
 
         # 現状、プロジェクト直下に.torrentファイルが落ちてくる
         urllib.request.urlretrieve(url, save_name)
 
-        info.show_info(save_name)
+        info.show_info(lt.torrent_info(save_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
わたしが作成したダウンロードのテストコードについて、torrentファイルがダウンロードされる階層を`nyaa_scraper.py`と揃えました。
`torrent/tests`配下にダウンロードします。

あわせて、以下の追加・変更も行いました。

- `.gitignore`に`*.torrent`ファイルを無視する設定を追加。ダウンロードしてきたtorrentファイルは管理する必要がないため。
- `tests`フォルダが消えないように、プレースホルダとして`.gitkeep`を追加。