### PR TITLE
requirements.txtを追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+###### Requirements ######
+beautifulsoup4
+bencodepy
+libtorrent
+torrentool


### PR DESCRIPTION
pythonにデフォルトで含まれていないパッケージは、各自がローカル環境で`pip install`をしなければ使えません。
これらのパッケージを管理するために`requirements.txt`ファイルを作成しておこうと思います。（今のところは大した量ではない、かつ、開発者がこれ以上増えるかもわからないのですが）

このファイルに必要なパッケージ名を書いておくことで、`pip install -r requirements.txt`コマンドにより一撃ですべてのパッケージが導入できるようになります。
参考: https://note.nkmk.me/python-pip-install-requirements/

