### PR TITLE
本体ファイルをダウンロードするClientクラスを追加

### DIFF
--- a/torrent/client.py
+++ b/torrent/client.py
@@ -1,0 +1,35 @@
+import libtorrent as lt
+import time
+
+
+class Client():
+
+    SAVE_PATH = "torrent/downloads"
+
+    def download(self, torrent_path):
+        """
+        torrentファイルを読み込み、本体ファイルをダウンロードする。
+
+        Parameters
+        ----------
+        torrent_path : str
+        ダウンロードを行うtorrentファイルへのパス。
+        """
+
+        session = lt.session({'listen_interfaces': '0.0.0.0:6881'})
+
+        info = lt.torrent_info(torrent_path)
+        handle = session.add_torrent({'ti': info, 'save_path': self.SAVE_PATH})
+
+        print('starting', handle.status().name)
+
+        while not handle.is_seed():
+            s = handle.status()
+
+            print("downloading: %.2f%% complete (down: %.1f kB/s, up: %.1f kB/s, peers: %d) %s" % (
+                s.progress * 100, s.download_rate / 1000, s.upload_rate / 1000,
+                s.num_peers, s.state))
+
+            time.sleep(1)
+
+        print(handle.status().name, 'complete')

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -3,22 +3,32 @@ import os
 import libtorrent as lt
 import urllib.request
 import info
+import client
 
 
 class TestInfo(unittest.TestCase):
     TEST_DIR = 'torrent/tests'
+    FILE_NAME = 'big-buck-bunny.torrent'
 
-    def test_show_info(self):
-        # テスト用にCreative Commons torrentを用いる
+    @classmethod
+    def setUpClass(self):
+        # テスト用にCreative Commons torrent をダウンロードする
         # Big Buck Bunny
         # Blender Foundation | www.blender.org
         url = 'https://webtorrent.io/torrents/big-buck-bunny.torrent'
-        save_name = os.path.join(self.TEST_DIR, 'big-buck-bunny.torrent')
 
-        # 現状、プロジェクト直下に.torrentファイルが落ちてくる
-        urllib.request.urlretrieve(url, save_name)
+        urllib.request.urlretrieve(
+            url, os.path.join(self.TEST_DIR, self.FILE_NAME))
 
-        info.show_info(lt.torrent_info(save_name))
+    # 現状、各メソッドを実行するだけで、assertionしていない。
+
+    def test_show_info(self):
+        info.show_info(lt.torrent_info(
+            os.path.join(self.TEST_DIR, self.FILE_NAME)))
+
+    def test_client(self):
+        cl = client.Client()
+        cl.download(os.path.join(self.TEST_DIR, self.FILE_NAME))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`download`メソッドの引数にローカルの`.torrent`ファイルのパスを指定することで、本体ファイルをダウンロードします。
ダウンロード先は、`torrent/downloads`です。
現状はただダウンロードしてくるだけで、アップロード速度の制御等は考慮していません。