### PR TITLE
テスト時のダウンロード先フォルダを変更

### DIFF
--- a/torrent/client.py
+++ b/torrent/client.py
@@ -4,9 +4,7 @@ import time
 
 class Client():
 
-    SAVE_PATH = "torrent/downloads"
-
-    def download(self, torrent_path):
+    def download(self, torrent_path, save_path):
         """
         torrentファイルを読み込み、本体ファイルをダウンロードする。
 
@@ -14,21 +12,25 @@ class Client():
         ----------
         torrent_path : str
         ダウンロードを行うtorrentファイルへのパス。
+        save_path : str
+        実ファイルのダウンロード先のパス。
         """
 
         session = lt.session({'listen_interfaces': '0.0.0.0:6881'})
 
         info = lt.torrent_info(torrent_path)
-        handle = session.add_torrent({'ti': info, 'save_path': self.SAVE_PATH})
+        handle = session.add_torrent({'ti': info, 'save_path': save_path})
 
         print('starting', handle.status().name)
 
         while not handle.is_seed():
             s = handle.status()
 
+            peer_info = handle.get_peer_info()
+
             print("downloading: %.2f%% complete (down: %.1f kB/s, up: %.1f kB/s, peers: %d) %s" % (
                 s.progress * 100, s.download_rate / 1000, s.upload_rate / 1000,
-                s.num_peers, s.state))
+                len(peer_info), s.state))
 
             time.sleep(1)
 

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -7,7 +7,8 @@ import client
 
 
 class TestInfo(unittest.TestCase):
-    TEST_DIR = 'tests'
+    TEST_DIR = 'torrent/tests'
+    DOWNLOAD_DIR = 'downloads'
     FILE_NAME = 'big-buck-bunny.torrent'
 
     @classmethod
@@ -28,7 +29,8 @@ class TestInfo(unittest.TestCase):
 
     def test_client(self):
         cl = client.Client()
-        cl.download(os.path.join(self.TEST_DIR, self.FILE_NAME))
+        cl.download(os.path.join(self.TEST_DIR, self.FILE_NAME),
+                    os.path.join(self.TEST_DIR, self.DOWNLOAD_DIR))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
フォルダ構成を整理したので、それに合わせてダウンロードのテストにおけるファイルを以下のようにしました。

テスト用のtorrentファイル: `torrent/tests`に格納。
テスト用の実ファイル: `torrent/tests/downloads`に格納。

テスト用のファイルは検証用のファイルとダウンロード場所を揃える必要はなく、`torrent`フォルダ内でテストを完結させたいため、このように変更しています。

これにより、 a3a675308d05f3a3de19c8f2e9f9209083abc478 における変更を差し戻したことになります。

フォルダ構成に関して認識違い等あれば、このpull requestをマージする前に教えてください。（githubの機能として、pull requestの内容を後から修正していくこともできるため）
よろしくお願いします！