### PR TITLE
ダウンロード中にピアのipアドレス、ポートを出力する

### DIFF
--- a/torrent/client.py
+++ b/torrent/client.py
@@ -32,6 +32,9 @@ class Client():
                 s.progress * 100, s.download_rate / 1000, s.upload_rate / 1000,
                 len(peer_info), s.state))
 
+            for p in peer_info:
+                print("IP address: %s   Port: %d" % (p.ip[0], p.ip[1]))
+
             time.sleep(1)
 
         print(handle.status().name, 'complete')

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -23,7 +23,7 @@ class Client():
 
         print('starting', handle.status().name)
 
-        while not handle.is_seed():
+        while not handle.status().is_seeding:
             s = handle.status()
 
             peer_info = handle.get_peer_info()


### PR DESCRIPTION
ダウンロード中に、接続しているpeerのIPアドレス、ポートを出力するようにしました。フォーマットは以下です。
`IP address: xxx.xxx.xxx.xxxx   Port: xxxx`

現状だとダウンロード進捗情報と同タイミングで（すなわち毎秒）ピアの情報を出力するので、けっこう出力されるログが多くなってしまいますが、保存のフォーマットが確定するまではいったん垂れ流しにしておこうと思います。

#14 で言及されていた

> 発信元ノード（ユーザの PC 等）のＩＰアドレス，ポート番号，ファイルハッシュ値，ファイルサイズ，ダウンロード完了時刻等

のうち、最初のふたつにあたります。