### PR TITLE
ピース単位でダウンロードを行うメソッドとテストを実装

### DIFF
--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -32,6 +32,14 @@ class TestInfo(unittest.TestCase):
         cl.download(os.path.join(self.TEST_DIR, self.FILE_NAME),
                     os.path.join(self.TEST_DIR, self.DOWNLOAD_DIR))
 
+    def test_download_piece(self):
+        cl = client.Client()
+        cl.download_piece(
+            os.path.join(self.TEST_DIR, self.FILE_NAME),
+            os.path.join(self.TEST_DIR, self.DOWNLOAD_DIR, 'pieces'),
+            0
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
ピース単位でダウンロードを行うメソッド（`download_piece`）を追加しました。
まだ証拠が収集できるような仕組みにはなっておらず、単にあるピースがダウンロードされたときにダウンロードが止まるだけのメソッドみたいな状態です。

テスト実行の方法は変わらず、`python3 torrent/test_download_torrent.py`です。