### PR TITLE
ピアごとにフォルダを分けてダウンロードできるようにする。

### DIFF
--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -3,6 +3,7 @@ import os
 import libtorrent as lt
 import urllib.request
 import client
+import csv
 import pathlib
 
 
@@ -31,11 +32,22 @@ class TestInfo(unittest.TestCase):
 
     def test_download_piece(self):
         cl = client.Client()
-        cl.download_piece(
-            os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME),
-            os.path.join(self.TEST_DIR, self.FOLDER_NAME),
-            0
-        )
+
+        peers = []
+        with open(os.path.join(self.TEST_DIR, self.FOLDER_NAME, 'peer.csv'), newline='') as csvfile:
+            reader = csv.reader(csvfile)
+            for row in reader:
+                # (IPアドレス : string, ポート : int) という型のタプルにする
+                peers.append((row[0], int(row[1])))
+
+        for p in peers:
+            print('download from {}'.format(p))
+            cl.download_piece(
+                os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME),
+                os.path.join(self.TEST_DIR, self.FOLDER_NAME, f'{p[0]}_{str(p[1])}'),
+                0,
+                p
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue #14 で議論しているピアごとの証拠ピース収集について実装を進めているので、途中経過的ではありますが、一旦プルリクエストを送らせてもらいます。

まず`Client.download`メソッドでファイル全体のダウンロードを行うと、そこで接続したピアの一覧が`peer.csv`に吐かれます。それを読み込んで`Client.download_piece`メソッドが各ピアからひとつのピースのダウンロードを試みるようになっています。

IPとピースを指定してのダウンロードはうまくいっているのですが、ピースをファイルとして書き出す処理がまだ実装できておらず、現状だと全体をダウンロードするときと変わらない見た目になっています。
（Big Buck Bunnyでテストしているのでそれを例にとると、仮にピースをひとつだけダウンロードしたときでも`Big Buck Bunny.mp4`ができてしまう）

あとは、当たり前と言えば当たり前なのですが、ピアをローカルに記録する形式だとすぐ古くなってしまうのでダウンロードできない場合が多いという問題も判明してきています。
ここは、トラッカー等から生きているピアを読み込むように仕組みを修正することを考えたほうがよいのかもしれません。

-----

参考画像: 
各ファイル名のフォルダ配下に`peer.csv`が作成され、それを読み込んで、IPアドレス名のフォルダにピースがダウンロードされます。
<img width="478" alt="スクリーンショット 2023-04-18 21 41 52" src="https://user-images.githubusercontent.com/115792382/232780670-8a91de87-6c70-4be2-b393-098fc0bc39e0.png">
