### PR TITLE
ピースを書き出す処理を追加

### DIFF
--- a/torrent/client.py
+++ b/torrent/client.py
@@ -18,7 +18,7 @@ class Client():
         Parameters
         ----------
         torrent_handle : torrent_handle
-        ピア情報を記録する対象のtorrent_handle。
+            ピア情報を記録する対象のtorrent_handle。
         """
         for p in torrent_handle.get_peer_info():
             self.peer_info.add(p.ip)
@@ -68,7 +68,7 @@ class Client():
             ファイルの保存場所のパス。
         piece_index : int
             ダウンロードしたいピースのindex。
-        peer : (string, int)
+        peer : (str, int)
             ピースをダウンロードするピア。
         """
 
@@ -164,7 +164,7 @@ def fetch_jst():
 
     Returns
     -------
-        jst_time: datetime
+    jst_time: datetime
         JSTを表すdatetime。
     """
     # NTPサーバのアドレスを指定する

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -123,7 +123,8 @@ class Client():
         for a in alerts:
             if isinstance(a, lt.read_piece_alert):
                 print('piece read')
-                write_piece_to_file(a.buffer, os.path.join(save_path, 'piece_{}.bin'.format(piece_index)))
+                write_piece_to_file(a.buffer, os.path.join(
+                    save_path, '{:05}_{}_{}_{}.bin'.format(piece_index, peer[0], peer[1], info.name())))
 
         # ピースのダウンロードが完了したら、ピースの状態を出力
         last_pieces_state = handle.status().pieces

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -100,6 +100,12 @@ class Client():
             print_download_status(handle.status(), handle.get_peer_info())
             print('piece {}: {}'.format(piece_index, handle.status().pieces[piece_index]))
 
+            # alertの出力を行う
+            alerts = session.pop_alerts()
+            for a in alerts:
+                if a.category() & lt.alert.category_t.error_notification:
+                    print(a)
+
             time.sleep(1)
 
             if handle.status().num_peers == 0:
@@ -110,6 +116,13 @@ class Client():
                 break
 
         handle.read_piece(piece_index)
+
+        # msで指定する
+        session.wait_for_alert(1000)
+        alerts = session.pop_alerts()
+        for a in alerts:
+            if isinstance(a, lt.read_piece_alert):
+                print('piece read')
 
         # ピースのダウンロードが完了したら、ピースの状態を出力
         last_pieces_state = handle.status().pieces

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -123,6 +123,7 @@ class Client():
         for a in alerts:
             if isinstance(a, lt.read_piece_alert):
                 print('piece read')
+                write_piece_to_file(a.buffer, os.path.join(save_path, 'piece_{}.bin'.format(piece_index)))
 
         # ピースのダウンロードが完了したら、ピースの状態を出力
         last_pieces_state = handle.status().pieces
@@ -139,6 +140,22 @@ def print_download_status(torrent_status, peer_info):
             torrent_status.upload_rate / 1000,
             len(peer_info), torrent_status.state)
     )
+
+
+def write_piece_to_file(piece, save_path):
+    """
+    ピースを指定されたパスに書き込む.
+
+    Parameters
+    ----------
+    piece : bytes
+        ピースのバイト列。
+
+    save_path : str
+        保存先ファイルのパス。
+    """
+    with open(save_path, 'wb') as f:
+        f.write(piece)
 
 
 def fetch_jst():


### PR DESCRIPTION
ダウンロードされたファイルから、ピース部分だけを`.bin`ファイルに書き出す処理を追加しました。
ファイル名は Issue #14 に記載の通り

> 00001_123.456.789.000_ポート番号_ファイル名

のような形式にしています。
あとは、同時に落ちてくるファイルの扱いをどうするか（`.bin`ファイルがあれば本体の方はいらない）問題が残っているので、そちらも追々対応しておきます。
ちょっと泥臭いですが、本体ファイルをいちいち削除する対応かなと考えています。