### PR TITLE
生きているseedの一覧を取得するメソッドを追加

### DIFF
--- a/torrent/client.py
+++ b/torrent/client.py
@@ -78,7 +78,8 @@ class Client():
         torrent_path : str
             .torrentファイルへのパス。
         save_path : str
-            ファイルの保存場所のパス。
+            ピースを保存するディレクトリのパス。
+            この引数で指定したディレクトリの直下に'IP_ポート番号'フォルダが作成され、その中にピースが保存される。
         piece_index : int
             ダウンロードしたいピースのindex。
         peer : (str, int)

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -121,7 +121,9 @@ class Client():
                 if isinstance(a, lt.read_piece_alert):
                     self.logger.info('piece read')
                     _write_piece_to_file(a.buffer, os.path.join(
-                        save_path, '{:05}_{}_{}_{}.bin'.format(piece_index, peer[0], peer[1], info.name())))
+                        save_path,
+                        f'{peer[0]}_{str(peer[1])}',
+                        '{:05}_{}_{}_{}.bin'.format(piece_index, peer[0], peer[1], info.name())))
 
     def __wait_for_download(self, session, torrent_handle, piece_index, max_retries):
         retry_counter = 0

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -11,21 +11,7 @@ from datetime import datetime, timezone, timedelta
 class Client():
     def __init__(self):
         logging.basicConfig(level=logging.INFO)
-        # 重複するピアを記録する必要はないため、集合として定義
-        self.peer_info = set()
         self.logger = logging.getLogger(__name__)
-
-    def add_peer_info(self, torrent_handle):
-        """
-        torrent_handleに含まれるピア情報を記録する。
-
-        Parameters
-        ----------
-        torrent_handle : torrent_handle
-            ピア情報を記録する対象のtorrent_handle。
-        """
-        for p in torrent_handle.get_peer_info():
-            self.peer_info.add(p.ip)
 
     def download(self, torrent_path, save_path):
         """
@@ -48,17 +34,40 @@ class Client():
 
         while not handle.status().is_seeding:
             _print_download_status(handle.status(), handle.get_peer_info(), self.logger)
-            self.add_peer_info(handle)
             time.sleep(1)
-
-        with open(os.path.join(save_path, 'peer.csv'), mode='a', newline='') as csvfile:
-            writer = csv.writer(csvfile)
-            for ip in self.peer_info:
-                writer.writerow([ip[0], ip[1]])
 
         self.logger.info('complete %s', handle.status().name)
         self.logger.info("File Hash: %s, File size: %d, Time: %s" % (
             handle.info_hash(), info.total_size(), _fetch_jst().strftime('%Y-%m-%d %H:%M:%S')))
+
+    def fetch_peer_list(self, torrent_path, max_list_size=20):
+        """
+        swarmに含まれるpeerのリストを取得する。
+        swarm: all peers (including seeds) sharing a torrent
+
+        Parameters
+        ----------
+        torrent_path : str
+            .torrentファイルへのパス。
+        max_list_size : int
+            取得されるピアのリストの最大長。
+
+        Returns
+        -------
+        peers : list of ('str', int)
+            ピアのリスト。
+        """
+        session = lt.session({'listen_interfaces': '0.0.0.0:6881'})
+        info = lt.torrent_info(torrent_path)
+
+        peers = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handle = session.add_torrent({'ti': info, 'save_path': tmpdir})
+            while len(peers) < max_list_size:
+                for p in handle.get_peer_info():
+                    if p.seed and (p.ip not in peers):
+                        peers.append(p.ip)
+        return peers[:max_list_size]
 
     def download_piece(self, torrent_path, save_path, piece_index, peer):
         """

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -20,7 +20,7 @@ class Client():
         Parameters
         ----------
         torrent_path : str
-            ダウンロードを行うtorrentファイルへのパス。
+            .torrentファイルへのパス。
         save_path : str
             本体ファイルのダウンロード先のパス。
         """

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -30,15 +30,17 @@ class TestClient(unittest.TestCase):
         cl.download(os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME),
                     os.path.join(self.TEST_DIR, self.FOLDER_NAME))
 
+    def test_fetch_peer_list(self):
+        cl = client.Client()
+        max_list_size = 10
+        peers = cl.fetch_peer_list(os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME), max_list_size)
+        print(peers)
+        self.assertTrue(len(peers) == max_list_size)
+
     def test_download_piece(self):
         cl = client.Client()
 
-        peers = []
-        with open(os.path.join(self.TEST_DIR, self.FOLDER_NAME, 'peer.csv'), newline='') as csvfile:
-            reader = csv.reader(csvfile)
-            for row in reader:
-                # (IPアドレス : string, ポート : int) という型のタプルにする
-                peers.append((row[0], int(row[1])))
+        peers = cl.fetch_peer_list(os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME), max_list_size=5)
 
         for p in peers:
             print('download from {}'.format(p))

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -7,7 +7,7 @@ import csv
 import pathlib
 
 
-class TestInfo(unittest.TestCase):
+class TestClient(unittest.TestCase):
     TEST_DIR = os.path.join(pathlib.Path(__file__).parent,
                             'tests', 'evidence', 'torrent')
     FOLDER_NAME = 'Big Buck Bunny'
@@ -25,7 +25,7 @@ class TestInfo(unittest.TestCase):
 
     # 現状、各メソッドを実行するだけで、assertionしていない。
 
-    def test_client(self):
+    def test_download(self):
         cl = client.Client()
         cl.download(os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME),
                     os.path.join(self.TEST_DIR, self.FOLDER_NAME))

--- a/torrent/test_download_torrent.py
+++ b/torrent/test_download_torrent.py
@@ -46,7 +46,7 @@ class TestClient(unittest.TestCase):
             print('download from {}'.format(p))
             cl.download_piece(
                 os.path.join(self.TEST_DIR, self.FOLDER_NAME, self.FILE_NAME),
-                os.path.join(self.TEST_DIR, self.FOLDER_NAME, f'{p[0]}_{str(p[1])}'),
+                os.path.join(self.TEST_DIR, self.FOLDER_NAME),
                 0,
                 p
             )


### PR DESCRIPTION
生きているseedの一覧を取得する`fetch_peer_list`メソッドを作成しました。
ピースダウンロードメソッドの前にこれを呼んでピアの一覧を取得すればよいので、他のメソッドの実装やテストがかなり容易になりました。
`download_piece`のテストについても、このメソッドを用いてピア一覧を取得するように修正しました。


このメソッドを作成したことにより、`peer.csv`の役割も変わる予定です。
これまでは「一回でもピースをダウンロードしたことがあるピア全て」を保存していましたが、今後は「ピースをダウンロードしたことがあるピア（シーダー）」を保存することになると思います。履歴管理のような位置づけです。

`peer.csv`関連の処理はいったん削除したので、現状はどこからも更新されなくなっています。