### PR TITLE
complete数関係の処理を削除

### DIFF
--- a/tests/test_download_torrent.py
+++ b/tests/test_download_torrent.py
@@ -34,14 +34,6 @@ class TestClient(unittest.TestCase):
         print(peers)
         self.assertTrue(len(peers) == max_list_size)
 
-    def test_save_num_complete(self):
-        cl = Client()
-
-        cl.save_num_complete(
-            os.path.join(self.TEST_DIR, self.FILE_NAME),
-            os.path.join(self.TEST_DIR, self.FOLDER_NAME)
-        )
-
     def test_download_piece(self):
         cl = Client()
 

--- a/torrent/client.py
+++ b/torrent/client.py
@@ -134,21 +134,6 @@ class Client():
                         )
                     )
 
-    def save_num_complete(self, torrent_path, save_path):
-        info = lt.torrent_info(torrent_path)
-
-        save_file_path = os.path.join(save_path, 'num_complete.log')
-        if not os.path.exists(save_file_path):
-            # ファイルが存在しない場合は作成してヘッダーを書き込み
-            with open(save_file_path, 'w') as f:
-                f.write('{} ファイルハッシュ: {}\n'.format(info.name(), info.info_hash()))
-                f.write('---\n')
-
-        with open(save_file_path, 'a') as f:
-            f.write('{}\n'.format(
-                ut.fetch_jst().strftime('%Y-%m-%d %H:%M:%S'),
-            ))
-
     def __wait_for_piece_download(self, session, torrent_handle, piece_index, max_retries):
         retry_counter = 0
 


### PR DESCRIPTION
complete数はクローラ側で取得することになったので、表題の通り、`client.py`の処理からは削除しておきます。